### PR TITLE
Fixa småbuggar i DDL och uppdatera logg_update-trigger:n så att den beräknar avstånd baserat på Pythagoras

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,10 @@ docker stop sctr-db
 docker rm sctr-db
 ```
 
+(if you like to keep your images tidy)
+Remove the image
+```bash
+docker rmi sctr/db:private
+```
+
 _Note_ that this is only for development - in the end, this repository's code and Dockerfile are to be used by a docker-compose file which combines all parts of the SCTR project.

--- a/sql-scripts/ddl.sql
+++ b/sql-scripts/ddl.sql
@@ -27,6 +27,8 @@ CREATE TABLE adm
     PRIMARY KEY (`id`)
 )
 ENGINE INNODB
+-- CHARSET utf8mb4
+-- COLLATE utf8_swedish_ci
 ;
 
 CREATE TABLE customer
@@ -40,8 +42,6 @@ CREATE TABLE customer
     PRIMARY KEY (`id`)
 )
 ENGINE INNODB
--- CHARSET utf8mb4
--- COLLATE utf8_swedish_ci
 ;
 
 CREATE TABLE city
@@ -220,7 +220,7 @@ BEGIN
 
         -- PARKING AT STATION AND/OR IN CITY ZONE
         --
-        -- 0 if ended/parked at a 'station/parking zone', 1 if ended/parked outside of one
+        -- 0 if ended/parked outside of 'station/parking zone', 1 if ended/parked within
         SET @ended_at_station = (
             SELECT EXISTS (
                 SELECT * FROM station

--- a/sql-scripts/ddl.sql
+++ b/sql-scripts/ddl.sql
@@ -31,7 +31,7 @@ CREATE TABLE customer
     `id` INT NOT NULL AUTO_INCREMENT,
     `username` CHAR(20) UNIQUE,
     `password` CHAR(255),
-    `funds` DECIMAL DEFAULT 0,
+    `funds` DECIMAL(7, 2) DEFAULT 0,
     `payment_terms` CHAR(10),
 
     PRIMARY KEY (`id`)
@@ -47,7 +47,7 @@ CREATE TABLE city
     `name` CHAR(20) NOT NULL UNIQUE,
     `lat_center` DECIMAL(9,6),
     `lon_center` DECIMAL(9,6),
-    `radius` DECIMAL,
+    `radius` DECIMAL(9, 6),
 
     PRIMARY KEY (`id`)
 )
@@ -61,7 +61,7 @@ CREATE TABLE station
     `location` CHAR(20),
     `lat_center` DECIMAL(9,6),
     `lon_center` DECIMAL(9,6),
-    `radius` DECIMAL DEFAULT 0.002,
+    `radius` DECIMAL(9, 6) DEFAULT 0.002,
     `charge` BOOLEAN NOT NULL DEFAULT 1, -- true
 
     PRIMARY KEY (`id`),
@@ -81,8 +81,8 @@ CREATE TABLE scooter
     `lon_pos` DECIMAL(9,6),
     `maintenance_mode` BOOLEAN DEFAULT 0, -- false
     `active` BOOLEAN DEFAULT 1, -- true
-    `speed` DECIMAL,
-    `battery_level` DECIMAL,
+    `speed_kph` INT DEFAULT 0,
+    `battery_level` DECIMAL(1, 4),
 
     PRIMARY KEY (`id`),
     FOREIGN KEY (`customer_id`) REFERENCES `customer` (`id`),
@@ -98,7 +98,7 @@ CREATE TABLE logg
     `customer_id` INT,
     `scooter_id` INT,
     `start_time` DATETIME DEFAULT CURRENT_TIMESTAMP,
-    `end_time` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `end_time` DATETIME DEFAULT NULL,
     `start_lat` DECIMAL(9,6),
     `start_lon` DECIMAL(9,6),
     `end_lat` DECIMAL(9,6),

--- a/sql-scripts/insert.sql
+++ b/sql-scripts/insert.sql
@@ -47,7 +47,7 @@ VALUES
 -- ------------------
 
 INSERT INTO
-    scooter (city_id, battery_level, speed, lat_pos,
+    scooter (city_id, battery_level, speed_kph, lat_pos,
     lon_pos)
 VALUES
     (1, 90, 0, 55.6004584, 13.0083306);

--- a/sql-scripts/insert.sql
+++ b/sql-scripts/insert.sql
@@ -25,9 +25,9 @@ INSERT INTO
     customer (username, password, funds, payment_terms)
 VALUES 
     ('janni', 'janni', 200.0, 'prepaid'), 
-    ('ahlstrm', 'frida', 1000.0, 'credit'),
+    ('ahlstrm', 'frida', 1000.0, 'invoice'),
     ('datalowe', 'lowe', 300.0, 'prepaid'),
-    ('jokris', 'johan', 450.0, 'credit');
+    ('jokris', 'johan', 450.0, 'invoice');
 
 
 -- ------------------
@@ -37,10 +37,19 @@ VALUES
 INSERT INTO
     city (name, lat_center, lon_center, radius)
 VALUES
-    ('Tidaholm', 58.1815656, 13.9546027, 0),
-    ('Bjästa', 63.2012144, 18.4735663, 0),
-    ('Klågerup', 55.5955693, 13.2308113, 0);
+    ('Tidaholm', 58.1815656, 13.9546027, 0.05),
+    ('Bjästa', 63.2012144, 18.4735663, 0.03),
+    ('Klågerup', 55.5955693, 13.2308113, 0.06);
 
+-- ------------------
+-- STATION TABLE ------
+-- ------------------
+
+INSERT INTO
+    station (city_id, location, lat_center, lon_center, radius)
+VALUES
+    (1, 'Tidaholm C', 58.1815656, 13.9546027, 0.002),
+    (2, 'Tidaholm Öster', 58.1815656, 13.9946027, 0.002);
 
 -- ------------------
 -- SCOOTER TABLE  --

--- a/sql-scripts/update.sql
+++ b/sql-scripts/update.sql
@@ -3,7 +3,30 @@ USE sctr; -- choose database (needed for MySQL Docker containers)
 -- SCOOTER UPDATE, TEST LOG  --
 -- -----------------------------
 
--- Rent scooter
+-- Rent scooter (user with 'prepaid' payment form)
+UPDATE
+	scooter
+SET
+	customer_id=1,
+    rented=1,
+    speed_kph=25
+WHERE
+	id=1;
+
+-- Return scooter far outside of home city radius (user with 'prepaid' payment form)
+UPDATE
+	scooter
+SET
+	customer_id = NULL,
+    rented=0,
+    speed_kph=0,
+    lat_pos=55.608061,
+    lon_pos=12.996175
+WHERE
+	id=1;
+
+
+-- Rent scooter far outside of home city radius (user with 'invoice' payment form)
 UPDATE
 	scooter
 SET
@@ -12,17 +35,67 @@ SET
     speed_kph=25
 WHERE
 	id=1;
-select * from logg;
 
--- Return scooter
+-- Return scooter far outside of home city radius  (user with 'invoice' payment form)
+-- should lead to 'penalty cost' being added because user parked outside of home city
 UPDATE
 	scooter
 SET
 	customer_id = NULL,
     rented=0,
     speed_kph=0,
-    lat_pos=55.6080612,
-    lon_pos=12.996175
+    lat_pos=55.608065,
+    lon_pos=12.996179
 WHERE
 	id=1;
-select * from logg;
+
+-- Rent scooter far outside of home city radius (user with 'invoice' payment form)
+UPDATE
+	scooter
+SET
+	customer_id=2,
+    rented=1,
+    speed_kph=25
+WHERE
+	id=1;
+
+-- Return scooter inside of home city radius, but not within a station's radius  (user with 'invoice' payment form)
+-- should lead to 'discount'/lowered start cost being applied because user parked outside of home city
+-- and 'parking within city' cost being added.
+UPDATE
+	scooter
+SET
+	customer_id = NULL,
+    rented=0,
+    speed_kph=0,
+    lat_pos=58.1815656,
+    lon_pos=13.9546127
+WHERE
+	id=1;
+
+
+
+-- Rent scooter placed within home city radius (user with 'invoice' payment form)
+UPDATE
+	scooter
+SET
+	customer_id=2,
+    rented=1,
+    speed_kph=25
+WHERE
+	id=1;
+
+-- Return scooter inside of station (user with 'invoice' payment form)
+-- should lead to 'parking within station' cost being added.
+UPDATE
+	scooter
+SET
+	customer_id = NULL,
+    rented=0,
+    speed_kph=0,
+    lat_pos=58.1815656,
+    lon_pos=13.9546027
+WHERE
+	id=1;
+
+SELECT * FROM logg;

--- a/sql-scripts/update.sql
+++ b/sql-scripts/update.sql
@@ -9,7 +9,7 @@ UPDATE
 SET
 	customer_id=2,
     rented=1,
-    speed=25
+    speed_kph=25
 WHERE
 	id=1;
 select * from logg;
@@ -20,7 +20,7 @@ UPDATE
 SET
 	customer_id = NULL,
     rented=0,
-    speed=0,
+    speed_kph=0,
     lat_pos=55.6080612,
     lon_pos=12.996175
 WHERE


### PR DESCRIPTION
Det finns några småbuggar och saknade specifikationer (för `DECIMAL` t ex - se issues) som fixas här. Det är enklast att se dem genom att titta på diffar för commits kopplade till den här PR:n.

Den större förändringen är att det i ddl.sql lags till en funktion `calc_geo_dist` som i sin tur används i triggern `logg_update`.

Principen som `calc_geo_dist` använder är väldigt enkel och bygger på Pythagoras, som illustreras här:
<img width="470" alt="exempel_avståndsberäkning" src="https://user-images.githubusercontent.com/65363390/141289402-da0d3f6d-5888-4827-8ff4-acfe379f95bc.png">
S markerar en elsparkcykels position vid parkering. Den röda cirkeln markerar en stations 'zon', definierad av stationens radie. För att komma fram till elsparkcykelns 'fågelvägsavstånd'/'direktavstånd' från stationens mittpunkt så används följande formel:

direktavstånd = sqrt( (dLat)^2 + (dLon)^2 )

där dLat är skillnaden mellan cykelns resp stationens latitud, och dLon är skillnaden mellan cykelns resp stationens longitud. sqrt betecknar 'roten ur'.

Det är alltså helt enkelt [Pythagoras formel](https://www.mathsisfun.com/pythagoras.html) som används.

`calc_geo_dist` används dels för att avgöra om elsparkcykeln är inom en stad (kollar om direktavstånd från cykeln till stadens mittpunkt är mindre än stadens radie), dels om den är inom en station/'parkeringszon' (kollar om direktavstånd från cykeln till stationens mittpunkt är mindre än stationens radie).

Jag har uppdaterat 'update.sql' och 'insert.sql' för att kunna testa den nya funktionalitet kopplad till `calc_geo_dist`. Det funkar som väntat utifrån de 'manuella testerna'. 