### PR TITLE
update Dockerfile and add related custom 'my.cnf' config file, to mak…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,12 @@ ENV MYSQL_ROOT_PASSWORD=fstr_hrdr_sctr
 COPY sql-scripts/setup.sql /docker-entrypoint-initdb.d/1-setup.sql
 COPY sql-scripts/ddl.sql /docker-entrypoint-initdb.d/2-ddl.sql
 COPY sql-scripts/insert.sql /docker-entrypoint-initdb.d/3-insert.sql
+
+# copy custom MySQL configuration file to enable reading from local
+# (CSV) files
+COPY docker-setup-files/custom_my.cnf /etc/mysql/my.cnf
+
+# copy the CSV files themselves (which are used to populate the database with
+# initial data) to root directory, since that is the 'working directory' when
+# the 'initdb' SQL scripts are executed
+COPY sql-scripts/*.csv /

--- a/docker-setup-files/custom_my.cnf
+++ b/docker-setup-files/custom_my.cnf
@@ -1,0 +1,39 @@
+# this is used with MySQL Docker images/containers to ensure that
+# reading from local files (ie CSV files with data for populating the
+# database) is allowed. The only parts that have been added are
+# 'local-infile' (under '[mysqld]') and '[mysql]' along with another
+# 'local-infile' line
+
+# Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+#
+# The MySQL  Server configuration file.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+[mysqld]
+pid-file        = /var/run/mysqld/mysqld.pid
+socket          = /var/run/mysqld/mysqld.sock
+datadir         = /var/lib/mysql
+secure-file-priv= NULL
+local-infile
+
+[mysql]
+local-infile
+
+# Custom config should go here
+!includedir /etc/mysql/conf.d/


### PR DESCRIPTION
…e import of local data (CSV file data) as used in insert.sql work correctly.

Tidigare gavs följande felmeddelande när man körde `docker build` och `docker run` så som det står i README:

```sql
2021-11-16 11:29:23+00:00 [Note] [Entrypoint]: /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/3-insert.sql
mbind: Operation not permitted
ERROR 2068 (HY000) at line 57: LOAD DATA LOCAL INFILE file request rejected due to restrictions on access.
```
Den här PR:n ordnar så att CSV-filer kopieras in i image, och tillåtelse i MySQL att använda 'local infile' konfigureras.