### PR TITLE
Improve/reset docker testdb

### DIFF
--- a/sql-scripts/reset-docker.bash
+++ b/sql-scripts/reset-docker.bash
@@ -1,0 +1,5 @@
+mysql -h 127.0.0.1 --port 6666 -u root -pfstr_hrdr_sctr < setup.sql > /dev/null
+
+mysql -h 127.0.0.1 --port 6666 -u root -pfstr_hrdr_sctr sctr < ddl.sql > /dev/null
+
+mysql -h 127.0.0.1 --port 6666 -u root -pfstr_hrdr_sctr sctr < insert.sql > /dev/null

--- a/sql-scripts/setup.sql
+++ b/sql-scripts/setup.sql
@@ -1,6 +1,7 @@
 SET NAMES 'utf8';
--- CREATE DATABASE
+-- CREATE DATABASE (and test database)
 DROP DATABASE IF EXISTS sctr;
+DROP DATABASE IF EXISTS test_sctr;
 -- set root password
 ALTER USER 'root'@'localhost'
 IDENTIFIED WITH caching_sha2_password

--- a/sql-scripts/setup.sql
+++ b/sql-scripts/setup.sql
@@ -7,6 +7,7 @@ IDENTIFIED WITH caching_sha2_password
 BY 'fstr_hrdr_sctr';
 
 CREATE DATABASE sctr CHARACTER SET utf8mb4 COLLATE utf8mb4_swedish_ci;
+CREATE DATABASE test_sctr CHARACTER SET utf8mb4 COLLATE utf8mb4_swedish_ci;
 
 -- USE DATABASE
 SHOW DATABASES LIKE "%sctr%"; -- show databases containing word 'scooter'


### PR DESCRIPTION
Det här lägger till en testdatabas 'test_sctr' som behövs för lokal testning i Laravel. Det lägger även till en variant på reset.bash, 'reset-docker.bash', som är till för att köras 'direkt på värddatorn' (dvs inte i en Dockercontainer, utan i en vanlig terminal på värddatorn) för att återställa databasen när den hanteras inuti en Dockercontainer.